### PR TITLE
Fix rescan test failure due to unset g_address_type, g_change_type

### DIFF
--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -451,6 +451,9 @@ BOOST_FIXTURE_TEST_CASE(rescan, TestChain100Setup)
 // than or equal to key birthday.
 BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
 {
+    g_address_type = OUTPUT_TYPE_DEFAULT;
+    g_change_type = OUTPUT_TYPE_DEFAULT;
+
     // Create two blocks with same timestamp to verify that importwallet rescan
     // will pick up both blocks, not just the first.
     const int64_t BLOCK_TIME = chainActive.Tip()->GetBlockTimeMax() + 5;


### PR DESCRIPTION
New global variables were introduced in #11403 and not setting them causes:

    test_bitcoin: wallet/wallet.cpp:4259: CTxDestination GetDestinationForKey(const CPubKey&, OutputType): Assertion `false' failed.
    unknown location(0): fatal error in "importwallet_rescan": signal: SIGABRT (application abort requested)

It's possible to reproduce the failure reliably by running:

    src/test/test_bitcoin --log_level=test_suite --run_test=wallet_tests/importwallet_rescan

Failures happen nondeterministically because boost test framework doesn't run
tests in a specified order, and tests that run previously can set the global
variables and mask the bug.

Github-Pull: #12424
Rebased-From: b7f6002ed5d12b461eb56b768d06f2468cd0c12e
Tree-SHA512: 1cc64db3b1d886d793e9d194b318dde3d5f628bde778a50513de4bf54dcfc77152885e72608927e3e490d253350ca0381847539a904cb31862f3a6fceac88dc1